### PR TITLE
docs: improve help message to highlight config show command

### DIFF
--- a/src/langsmith_cli/cli.py
+++ b/src/langsmith_cli/cli.py
@@ -48,6 +48,9 @@ def main():
       langsmith-fetch thread <thread-id>                  # Fetch a specific thread by ID
       langsmith-fetch traces ./dir --limit 10             # Fetch 10 traces to directory (RECOMMENDED)
       langsmith-fetch threads ./dir --limit 10            # Fetch 10 threads to directory (RECOMMENDED)
+
+    CONFIGURATION:
+      langsmith-fetch config show                         # View current configuration
       langsmith-fetch config set project-uuid <uuid>      # Configure project UUID
       langsmith-fetch config set api-key <key>            # Store API key in config
 
@@ -831,10 +834,13 @@ def config_cmd():
 
     \b
     EXAMPLES:
+      # Check current configuration
+      langsmith-fetch config show
+
+      # Set configuration values
       langsmith-fetch config set project-uuid 80f1ecb3-a16b-411e-97ae-1c89adbb5c49
       langsmith-fetch config set api-key lsv2_...
       langsmith-fetch config set default-format json
-      langsmith-fetch config show
     """
     pass
 


### PR DESCRIPTION
## Summary
- Add dedicated CONFIGURATION section to main help output
- Reorganize config examples to prominently display `config show` as first command
- Make it easier for users to discover how to check their current configuration

## Context
Users were confused about how to view their configuration, attempting invalid commands like `config list` because `config show` wasn't prominently displayed in the help output.

## Changes
- Added CONFIGURATION section in main help separating config commands from common fetch commands
- Moved `config show` to the top of examples in `config --help` with explanatory comments
- Added clear workflow: check config first, then set values as needed

## Test plan
- Run `langsmith-fetch --help` and verify CONFIGURATION section is visible
- Run `langsmith-fetch config --help` and verify examples show `config show` first
- Verify the help messages clearly guide users to check config before setting values