### PR TITLE
Add optional LANGSMITH_ENDPOINT variable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Set your LangSmith API key and project name:
 ```bash
 export LANGSMITH_API_KEY=lsv2_...
 export LANGSMITH_PROJECT=your-project-name
+# Optional: define your endpoint - defaults to 'us'
+export LANGSMITH_ENDPOINT=https://us.api.smith.langchain.com
 ```
 
 That's it! The CLI will automatically fetch traces or threads in `LANGSMITH_PROJECT`.


### PR DESCRIPTION
Was having issues setting it up. Fixed it by setting `LANGSMITH_ENDPOINT` to `eu.api.smith`. Thought it would be nice to showcase the option in readme.